### PR TITLE
change mecanumDrive method to tankDrive method

### DIFF
--- a/CommandRobot/src/org/usfirst/frc/team2989/robot/subsystems/DriveTrain.java
+++ b/CommandRobot/src/org/usfirst/frc/team2989/robot/subsystems/DriveTrain.java
@@ -20,7 +20,7 @@ public class DriveTrain extends Subsystem {
 		setDefaultCommand(new TeleopDriveCommand());
 	}
 	
-	public void driveRobot(double x, double y, double rotation, double angle) {
-		robotDrive.mecanumDrive_Cartesian(x, y, rotation, angle);
+	public void driveRobot(double x, double y, boolean sqauredInputs ) {
+		robotDrive.tankDrive(x, y, true);
 	}
 }


### PR DESCRIPTION
mecanumDrive method is meant to be used on robots with mecanum wheels pointed 45 degrees. Tank drive is appropriate for our robot